### PR TITLE
Add support for dark them by AI (JetBrains Junie)

### DIFF
--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -9,3 +9,52 @@
 pre code.hljs {
     border-radius: .6em;
 }
+
+/* ANSI Theme styles for light/dark mode */
+.ansi-theme-container .ansi_color_fg_black { color: black; }
+.ansi-theme-container .ansi_color_fg_red { color: darkred; }
+.ansi-theme-container .ansi_color_fg_green { color: green; }
+.ansi-theme-container .ansi_color_fg_yellow { color: orange; }
+.ansi-theme-container .ansi_color_fg_blue { color: blue; }
+.ansi-theme-container .ansi_color_fg_magenta { color: darkmagenta; }
+.ansi-theme-container .ansi_color_fg_cyan { color: cyan; }
+.ansi-theme-container .ansi_color_fg_white { color: white; }
+
+.ansi-theme-container .ansi_color_bg_black { background-color: black; }
+.ansi-theme-container .ansi_color_bg_red { background-color: red; }
+.ansi-theme-container .ansi_color_bg_green { background-color: green; }
+.ansi-theme-container .ansi_color_bg_yellow { background-color: lightyellow; }
+.ansi-theme-container .ansi_color_bg_blue { background-color: blue; }
+.ansi-theme-container .ansi_color_bg_magenta { background-color: magenta; }
+.ansi-theme-container .ansi_color_bg_cyan { background-color: lightcyan; }
+.ansi-theme-container .ansi_color_bg_white { background-color: white; }
+
+.ansi-theme-container .ansi_color_bg_#ef7373 { background-color: #ef7373; }
+
+/* Dark mode overrides */
+.dark .ansi-theme-container .ansi_color_fg_black { color: #cccccc; }
+.dark .ansi-theme-container .ansi_color_fg_red { color: #ff5555; }
+.dark .ansi-theme-container .ansi_color_fg_green { color: #55ff55; }
+.dark .ansi-theme-container .ansi_color_fg_yellow { color: #ffff55; }
+.dark .ansi-theme-container .ansi_color_fg_blue { color: #5555ff; }
+.dark .ansi-theme-container .ansi_color_fg_magenta { color: #ff55ff; }
+.dark .ansi-theme-container .ansi_color_fg_cyan { color: #55ffff; }
+.dark .ansi-theme-container .ansi_color_fg_white { color: #ffffff; }
+
+.dark .ansi-theme-container .ansi_color_fg_#ef7373 { color: #ff9999; }
+
+.dark .ansi-theme-container .ansi_color_bg_black { background-color: #333333; }
+.dark .ansi-theme-container .ansi_color_bg_red { background-color: #aa0000; }
+.dark .ansi-theme-container .ansi_color_bg_green { background-color: #00aa00; }
+.dark .ansi-theme-container .ansi_color_bg_yellow { background-color: #aaaa00; }
+.dark .ansi-theme-container .ansi_color_bg_blue { background-color: #0000aa; }
+.dark .ansi-theme-container .ansi_color_bg_magenta { background-color: #aa00aa; }
+.dark .ansi-theme-container .ansi_color_bg_cyan { background-color: #00aaaa; }
+.dark .ansi-theme-container .ansi_color_bg_white { background-color: #aaaaaa; }
+
+.dark .ansi-theme-container .ansi_color_bg_#ef7373 { background-color: #cc5555; }
+
+/* Add transition for smooth theme switching */
+.ansi-theme-container span {
+    transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}

--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -27,30 +27,30 @@ pre code.hljs {
 .ansi-theme-container .ansi_color_bg_blue { background-color: blue; }
 .ansi-theme-container .ansi_color_bg_magenta { background-color: magenta; }
 .ansi-theme-container .ansi_color_bg_cyan { background-color: lightcyan; }
-.ansi-theme-container .ansi_color_bg_white { background-color: white; }
+.ansi-theme-container .ansi_color_bg_white { }
 
 .ansi-theme-container .ansi_color_bg_#ef7373 { background-color: #ef7373; }
 
 /* Dark mode overrides */
-.dark .ansi-theme-container .ansi_color_fg_black { color: #cccccc; }
+.dark .ansi-theme-container .ansi_color_fg_black { color: white; }
 .dark .ansi-theme-container .ansi_color_fg_red { color: #ff5555; }
 .dark .ansi-theme-container .ansi_color_fg_green { color: #55ff55; }
 .dark .ansi-theme-container .ansi_color_fg_yellow { color: #ffff55; }
 .dark .ansi-theme-container .ansi_color_fg_blue { color: #5555ff; }
 .dark .ansi-theme-container .ansi_color_fg_magenta { color: #ff55ff; }
 .dark .ansi-theme-container .ansi_color_fg_cyan { color: #55ffff; }
-.dark .ansi-theme-container .ansi_color_fg_white { color: #ffffff; }
+.dark .ansi-theme-container .ansi_color_fg_white { color: #333333; }
 
 .dark .ansi-theme-container .ansi_color_fg_#ef7373 { color: #ff9999; }
 
-.dark .ansi-theme-container .ansi_color_bg_black { background-color: #333333; }
+.dark .ansi-theme-container .ansi_color_bg_black { background-color: white; }
 .dark .ansi-theme-container .ansi_color_bg_red { background-color: #aa0000; }
 .dark .ansi-theme-container .ansi_color_bg_green { background-color: #00aa00; }
 .dark .ansi-theme-container .ansi_color_bg_yellow { background-color: #aaaa00; }
 .dark .ansi-theme-container .ansi_color_bg_blue { background-color: #0000aa; }
 .dark .ansi-theme-container .ansi_color_bg_magenta { background-color: #aa00aa; }
 .dark .ansi-theme-container .ansi_color_bg_cyan { background-color: #00aaaa; }
-.dark .ansi-theme-container .ansi_color_bg_white { background-color: #aaaaaa; }
+.dark .ansi-theme-container .ansi_color_bg_white { }
 
 .dark .ansi-theme-container .ansi_color_bg_#ef7373 { background-color: #cc5555; }
 

--- a/app/assets/js/app/editor.js
+++ b/app/assets/js/app/editor.js
@@ -1,11 +1,20 @@
 import * as monaco from 'monaco-editor';
 
 let diffEditor;
+let codeEditorInstance;
+let testEditorInstance;
+let configEditorInstance;
 
 export function initMutationEditors() {
-    const codeEditor = initCodeEditor();
-    const testEditor = initTestEditor();
-    const configEditor = initConfigEditor();
+    codeEditorInstance = initCodeEditor();
+    testEditorInstance = initTestEditor();
+    configEditorInstance = initConfigEditor();
+
+    // Set initial theme based on current mode
+    updateEditorsTheme();
+
+    // Listen for theme changes
+    document.addEventListener('themeChanged', updateEditorsTheme);
 
     processMutantsDetails();
 
@@ -217,7 +226,8 @@ function showDiffEditor(mutator) {
         enableSplitViewResizing: false,
         // Render the diff inline
         renderSideBySide: false,
-        readOnly: true
+        readOnly: true,
+        theme: isCurrentThemeDark() ? 'vs-dark' : 'vs'
     });
 
     diffEditor.setModel({
@@ -250,8 +260,15 @@ export function initAstEditor() {
             enabled: false
         },
         value: code,
-        language: 'php'
+        language: 'php',
+        theme: isCurrentThemeDark() ? 'vs-dark' : 'vs'
     });
+
+    // Set initial theme based on current mode
+    updateEditorsTheme();
+
+    // Listen for theme changes
+    document.addEventListener('themeChanged', updateEditorsTheme);
 
     document.getElementById('js-submit').addEventListener(
         'click',
@@ -304,7 +321,8 @@ function initCodeEditor() {
             enabled: false
         },
         value: code,
-        language: 'php'
+        language: 'php',
+        theme: isCurrentThemeDark() ? 'vs-dark' : 'vs'
     });
 }
 
@@ -347,7 +365,8 @@ function initTestEditor() {
             enabled: false
         },
         value: code,
-        language: 'php'
+        language: 'php',
+        theme: isCurrentThemeDark() ? 'vs-dark' : 'vs'
     });
 }
 
@@ -375,5 +394,37 @@ function initConfigEditor() {
         },
         value: code,
         language: 'json',
+        theme: isCurrentThemeDark() ? 'vs-dark' : 'vs'
     });
+}
+
+/**
+ * Check if the current theme is dark
+ * @returns {boolean}
+ */
+function isCurrentThemeDark() {
+    return document.documentElement.classList.contains('dark');
+}
+
+/**
+ * Update the theme for all Monaco editors based on the current theme
+ */
+function updateEditorsTheme() {
+    const theme = isCurrentThemeDark() ? 'vs-dark' : 'vs';
+
+    monaco.editor.setTheme(theme);
+
+    // Force layout update to ensure proper rendering
+    if (codeEditorInstance) {
+        codeEditorInstance.layout();
+    }
+    if (testEditorInstance) {
+        testEditorInstance.layout();
+    }
+    if (configEditorInstance) {
+        configEditorInstance.layout();
+    }
+    if (diffEditor) {
+        diffEditor.layout();
+    }
 }

--- a/app/assets/js/app/editor.js
+++ b/app/assets/js/app/editor.js
@@ -1,14 +1,14 @@
 import * as monaco from 'monaco-editor';
 
 let diffEditor;
-let codeEditorInstance;
-let testEditorInstance;
-let configEditorInstance;
+let codeEditor;
+let testEditor;
+let configEditor;
 
 export function initMutationEditors() {
-    codeEditorInstance = initCodeEditor();
-    testEditorInstance = initTestEditor();
-    configEditorInstance = initConfigEditor();
+    codeEditor = initCodeEditor();
+    testEditor = initTestEditor();
+    configEditor = initConfigEditor();
 
     // Set initial theme based on current mode
     updateEditorsTheme();
@@ -415,14 +415,14 @@ function updateEditorsTheme() {
     monaco.editor.setTheme(theme);
 
     // Force layout update to ensure proper rendering
-    if (codeEditorInstance) {
-        codeEditorInstance.layout();
+    if (codeEditor) {
+        codeEditor.layout();
     }
-    if (testEditorInstance) {
-        testEditorInstance.layout();
+    if (testEditor) {
+        testEditor.layout();
     }
-    if (configEditorInstance) {
-        configEditorInstance.layout();
+    if (configEditor) {
+        configEditor.layout();
     }
     if (diffEditor) {
         diffEditor.layout();

--- a/app/assets/js/app/editor.js
+++ b/app/assets/js/app/editor.js
@@ -130,14 +130,14 @@ function showMutantsTable(mutants) {
     mutants.forEach((mutant, index) => {
         const td1 = document.createElement('td');
 
-        td1.className = 'border-dashed border-t border-gray-200';
+        td1.className = 'border-dashed border-t border-gray-200 dark:border-gray-700';
         const span1 = document.createElement('span');
-        span1.className = 'text-gray-700 px-6 py-3 flex items-center';
+        span1.className = 'text-gray-700 dark:text-gray-300 px-6 py-3 flex items-center';
         span1.textContent = `${index + 1}. ` + mutant.mutator.mutatorName; // + ', Line: ' + mutant.mutator.originalStartLine;
         td1.appendChild(span1);
         const td2 = document.createElement('td');
 
-        td1.className = 'border-dashed border-t border-gray-200';
+        td1.className = 'border-dashed border-t border-gray-200 dark:border-gray-700';
         const span2 = document.createElement('span');
         span2.className = 'rounded py-1 px-3 text-xs font-bold' + ' bg-' + colorsMap[mutant.status] + '-400';
         span2.textContent = mutant.status;
@@ -145,7 +145,7 @@ function showMutantsTable(mutants) {
 
         const tr = document.createElement('tr');
         tr.appendChild(td1);
-        tr.className = 'cursor-pointer hover:bg-gray-100';
+        tr.className = 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700';
         tr.appendChild(td2);
 
         tBody.appendChild(tr);
@@ -168,12 +168,12 @@ function unhighlightAllRows() {
     const rows = Array.prototype.slice.call(htmlCollection);
 
     rows.forEach((row) => {
-        row.classList.remove('bg-gray-200');
+        row.classList.remove('bg-gray-200', 'dark:bg-gray-700');
     });
 }
 
 function highlightRow(row) {
-    row.classList.add('bg-gray-200');
+    row.classList.add('bg-gray-200', 'dark:bg-gray-700');
 }
 
 function showProcessOutput(mutant) {

--- a/app/src/Controller/PlaygroundController.php
+++ b/app/src/Controller/PlaygroundController.php
@@ -155,7 +155,7 @@ class PlaygroundController extends AbstractController
 
         $form = $this->createForm(CreateExampleType::class, $createExampleRequest);
 
-        $converter = new AnsiToHtmlConverter(new InfectionAnsiHtmlTheme());
+        $converter = new AnsiToHtmlConverter(new InfectionAnsiHtmlTheme(), false);
         $converter->setInvertBackground(true);
 
         return $this->render('playground/index.html.twig', [

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     "./assets/**/*.js",
     "./templates/**/*.html.twig",
   ],
+  darkMode: 'class',
   theme: {
     extend: {},
   },

--- a/app/templates/ast/_form.html.twig
+++ b/app/templates/ast/_form.html.twig
@@ -4,14 +4,14 @@
 
 {{ form_start(form) }}
     <div class="flex">
-        <div class="flex-1 text-gray-700 bg-gray-200 px-1 py-1 my-2">
+        <div class="flex-1 text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 px-1 py-1 my-2">
             <div id="editor-code-ast" style="height:400px;"></div>
             <div class="hidden">{{ form_widget(form.code) }}</div>
             {{ form_errors(form.code) }}
         </div>
     </div>
 
-    <button id="js-submit" class="bg-transparent hover:bg-green-500 text-green-700 font-semibold hover:text-white py-2 px-4 border border-green-500 hover:border-transparent rounded inline-flex items-center" type="button">
+    <button id="js-submit" class="bg-transparent dark:bg-gray-800 hover:bg-green-500 dark:hover:bg-green-600 text-green-700 dark:text-green-400 font-semibold hover:text-white dark:hover:text-white py-2 px-4 border border-green-500 dark:border-green-600 hover:border-transparent dark:hover:border-transparent rounded inline-flex items-center transition-colors duration-200" type="button">
         <svg class="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M4 4l12 6-12 6z"/></svg>
         <span>{{ astRun is defined ? 'Rebuild' : 'Build' }} AST</span>
     </button>

--- a/app/templates/ast/create.html.twig
+++ b/app/templates/ast/create.html.twig
@@ -8,5 +8,6 @@
 {% endblock %}
 
 {% block javascripts %}
+    {{ parent() }}
     {{ encore_entry_script_tags('ast') }}
 {% endblock %}

--- a/app/templates/ast/index.html.twig
+++ b/app/templates/ast/index.html.twig
@@ -48,6 +48,7 @@
 {% endblock %}
 
 {% block javascripts %}
+    {{ parent() }}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/php.min.js"></script>
 

--- a/app/templates/ast/index.html.twig
+++ b/app/templates/ast/index.html.twig
@@ -5,25 +5,25 @@
 {% block body %}
     <div class="container w-full md:max-w-3xl mx-auto pb-4">
         {% if astRun is defined %}
-            <p class="py-6"><span class="font-bold">Click</span> on code part to see its AST</p>
-            <pre id="clickable-nodes-code"><code class="hljs">&lt;?php
+            <p class="py-6 dark:text-gray-200"><span class="font-bold">Click</span> on code part to see its AST</p>
+            <pre id="clickable-nodes-code" class="dark:bg-gray-800"><code class="hljs dark:bg-gray-800 dark:text-gray-200">&lt;?php
 {{ clickableNodesDump|raw }}</code></pre>
 
-            <p class="py-6">Selected code is represented by following abstract syntax tree:</p>
+            <p class="py-6 dark:text-gray-200">Selected code is represented by following abstract syntax tree:</p>
 
             <div class="row">
                 <div class="col-12">
-                    <pre><code class="language-php">{{ simpleNodeDump }}</code></pre>
+                    <pre class="dark:bg-gray-800"><code class="language-php dark:bg-gray-800 dark:text-gray-200">{{ simpleNodeDump }}</code></pre>
                 </div>
             </div>
 
             {% if targetNodeClass %}
-                <p class="py-6">In <code>Mutator::canMutate()</code> method you can use the following node to mutate it:</p>
-                <pre><code class="language-php">{{ targetNodeClass }}</code></pre>
+                <p class="py-6 dark:text-gray-200">In <code class="dark:bg-gray-700 dark:text-gray-200">Mutator::canMutate()</code> method you can use the following node to mutate it:</p>
+                <pre class="dark:bg-gray-800"><code class="language-php dark:bg-gray-800 dark:text-gray-200">{{ targetNodeClass }}</code></pre>
             {% endif %}
         {% endif %}
 
-        <p class="py-6">
+        <p class="py-6 dark:text-gray-200">
             {% if astRun is defined %}
                 Update the code and generate new AST:
             {% else %}
@@ -36,7 +36,7 @@
 
         <div class="flex w-full items-center font-light px-4 py-12">
             <div class="flex-1 px-2">
-                <p class="text-gray-600 text-xs md:text-base">This AST explorer is highly insired by and uses <a class="text-green-500 no-underline hover:underline" href="https://getrector.com/ast">Rector PHP's</a> code (MIT license)</p>
+                <p class="text-gray-600 dark:text-gray-400 text-xs md:text-base">This AST explorer is highly insired by and uses <a class="text-green-500 dark:text-green-400 no-underline hover:underline" href="https://getrector.com/ast">Rector PHP's</a> code (MIT license)</p>
             </div>
         </div>
     </div>

--- a/app/templates/base.html.twig
+++ b/app/templates/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="light">
     <head>
         <meta charset="UTF-8">
 
@@ -14,41 +14,98 @@
             {# 'app' must match the first argument to addEntry() in webpack.config.js #}
             {{ encore_entry_link_tags('app') }}
         {% endblock %}
+
+        <script>
+            // Check for saved theme preference or use the system preference
+            if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                document.documentElement.classList.add('dark');
+                document.documentElement.classList.remove('light');
+            } else {
+                document.documentElement.classList.remove('dark');
+                document.documentElement.classList.add('light');
+            }
+        </script>
     </head>
-    <body>
-        <nav class="w-full z-20 flex items-center justify-between flex-wrap bg-white py-4 px-2 sm:px-6 border border-gray-200">
-            <a href="https://infection-php.dev/" class="no-underline flex items-center flex-no-shrink text-white mr-6">
+    <body class="bg-white dark:bg-gray-900 transition-colors duration-200">
+        <nav class="w-full z-20 flex items-center justify-between flex-wrap bg-white dark:bg-gray-800 py-4 px-2 sm:px-6 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
+            <a href="https://infection-php.dev/" class="no-underline flex items-center flex-no-shrink mr-6">
                 <img class="h-8 w-8 mr-2" src="{{ asset('build/logo.png') }}" alt="Infection logo">
-                <span class="font-medium text-xl tracking-tighter text-green-500">Infection Playground</span>
+                <span class="font-medium text-xl tracking-tighter text-green-500 dark:text-green-400">Infection Playground</span>
             </a>
             <div class="w-full hidden flex-grow lg:flex lg:items-center lg:w-auto">
                 <div class="text-sm lg:flex-grow ">
-                    <a href="{{ path('app_ast_index') }}" class="block mt-4 lg:inline-block text-gray-600 lg:mt-0 hover:text-gray-900 mr-4 no-underline">
+                    <a href="{{ path('app_ast_index') }}" class="block mt-4 lg:inline-block text-gray-600 dark:text-gray-300 lg:mt-0 hover:text-gray-900 dark:hover:text-white mr-4 no-underline">
                         AST Explorer
                     </a>
-                    <a href="https://infection.github.io/" target="_blank" class="block mt-4 lg:inline-block text-gray-600 lg:mt-0 hover:text-gray-900 mr-4 no-underline">
+                    <a href="https://infection.github.io/" target="_blank" class="block mt-4 lg:inline-block text-gray-600 dark:text-gray-300 lg:mt-0 hover:text-gray-900 dark:hover:text-white mr-4 no-underline">
                         Documentation
                     </a>
                     <a href="https://github.com/infection/infection"
                        target="_blank"
-                       class="block mt-4 lg:inline-block lg:mt-0 text-gray-600 hover:text-gray-900 mr-4 no-underline">
+                       class="block mt-4 lg:inline-block lg:mt-0 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white mr-4 no-underline">
                         GitHub
                     </a>
                     <a href="https://github.com/infection/playground"
                        target="_blank"
-                       class="block mt-4 lg:inline-block lg:mt-0 text-gray-600 hover:text-gray-900 no-underline">
+                       class="block mt-4 lg:inline-block lg:mt-0 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white no-underline">
                         Found issue? Contribute!
                     </a>
                 </div>
-                <div>
-                    <p class="text-gray-500">PHP Mutation Testing</p>
+                <div class="flex items-center">
+                    <p class="text-gray-500 dark:text-gray-300 mr-4">PHP Mutation Testing</p>
+                    <button id="theme-toggle" type="button" class="text-gray-500 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5">
+                        <svg id="theme-toggle-dark-icon" class="hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
+                        </svg>
+                        <svg id="theme-toggle-light-icon" class="hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path>
+                        </svg>
+                    </button>
                 </div>
             </div>
         </nav>
-        <div class="w-full relative bg-white px-2">
+        <div class="w-full relative bg-white dark:bg-gray-900 px-2 text-gray-900 dark:text-gray-100 transition-colors duration-200">
             {% block body %}{% endblock %}
         </div>
 
         {% block javascripts %}{% endblock %}
+
+        <script>
+            // Function to toggle between light and dark mode
+            function toggleTheme() {
+                // Toggle dark class on html element
+                const htmlElement = document.documentElement;
+                if (htmlElement.classList.contains('dark')) {
+                    htmlElement.classList.remove('dark');
+                    htmlElement.classList.add('light');
+                    localStorage.theme = 'light';
+                } else {
+                    htmlElement.classList.remove('light');
+                    htmlElement.classList.add('dark');
+                    localStorage.theme = 'dark';
+                }
+                updateIcons();
+            }
+
+            // Function to update the visibility of the icons based on the current theme
+            function updateIcons() {
+                const darkIcon = document.getElementById('theme-toggle-dark-icon');
+                const lightIcon = document.getElementById('theme-toggle-light-icon');
+
+                if (document.documentElement.classList.contains('dark')) {
+                    darkIcon.classList.add('hidden');
+                    lightIcon.classList.remove('hidden');
+                } else {
+                    lightIcon.classList.add('hidden');
+                    darkIcon.classList.remove('hidden');
+                }
+            }
+
+            // Add event listener to the theme toggle button
+            document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+
+            // Initialize the correct icon on page load
+            document.addEventListener('DOMContentLoaded', updateIcons);
+        </script>
     </body>
 </html>

--- a/app/templates/base.html.twig
+++ b/app/templates/base.html.twig
@@ -103,6 +103,17 @@
 
                 // Initialize the correct icon on page load
                 document.addEventListener('DOMContentLoaded', updateThemeIcons);
+
+                // Listen for changes in system color scheme preference
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+                    // react even user has a preference in local storage (same as vite press does it)
+                    const isDark = event.matches;
+                    document.documentElement.classList.toggle('dark', isDark);
+                    updateThemeIcons();
+
+                    // Dispatch custom event for Monaco editors
+                    document.dispatchEvent(new CustomEvent('themeChanged'));
+                });
             </script>
         {% endblock %}
     </body>

--- a/app/templates/base.html.twig
+++ b/app/templates/base.html.twig
@@ -1,7 +1,19 @@
 <!DOCTYPE html>
-<html class="light">
+<html>
     <head>
         <meta charset="UTF-8">
+
+        <script>
+            // On page load, set the theme
+            const userTheme = localStorage.getItem('theme');
+            const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
+            if (userTheme === 'dark' || (!userTheme && systemTheme === 'dark')) {
+                document.documentElement.classList.add('dark');
+            } else {
+                document.documentElement.classList.remove('dark');
+            }
+        </script>
 
         <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('build/icons/apple-touch-icon.png') }}">
         <link rel="icon" type="image/png" sizes="192x192"  href="{{ asset('build/icons/android-icon-192x192.png') }}">
@@ -14,17 +26,6 @@
             {# 'app' must match the first argument to addEntry() in webpack.config.js #}
             {{ encore_entry_link_tags('app') }}
         {% endblock %}
-
-        <script>
-            // Check for saved theme preference or use the system preference
-            if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-                document.documentElement.classList.add('dark');
-                document.documentElement.classList.remove('light');
-            } else {
-                document.documentElement.classList.remove('dark');
-                document.documentElement.classList.add('light');
-            }
-        </script>
     </head>
     <body class="bg-white dark:bg-gray-900 transition-colors duration-200">
         <nav class="w-full z-20 flex items-center justify-between flex-wrap bg-white dark:bg-gray-800 py-4 px-2 sm:px-6 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
@@ -68,47 +69,41 @@
             {% block body %}{% endblock %}
         </div>
 
-        {% block javascripts %}{% endblock %}
+        {% block javascripts %}
+            <script>
+                // Function to update the visibility of the icons based on the current theme
+                function updateThemeIcons() {
+                    const darkIcon = document.getElementById('theme-toggle-dark-icon');
+                    const lightIcon = document.getElementById('theme-toggle-light-icon');
 
-        <script>
-            // Function to toggle between light and dark mode
-            function toggleTheme() {
-                // Toggle dark class on html element
-                const htmlElement = document.documentElement;
-                if (htmlElement.classList.contains('dark')) {
-                    htmlElement.classList.remove('dark');
-                    htmlElement.classList.add('light');
-                    localStorage.theme = 'light';
-                } else {
-                    htmlElement.classList.remove('light');
-                    htmlElement.classList.add('dark');
-                    localStorage.theme = 'dark';
+                    if (darkIcon && lightIcon) {
+                        if (document.documentElement.classList.contains('dark')) {
+                            darkIcon.classList.add('hidden');
+                            lightIcon.classList.remove('hidden');
+                        } else {
+                            lightIcon.classList.add('hidden');
+                            darkIcon.classList.remove('hidden');
+                        }
+                    }
                 }
-                updateIcons();
 
-                // Dispatch custom event for Monaco editors
-                document.dispatchEvent(new CustomEvent('themeChanged'));
-            }
+                // Function to toggle between light and dark mode
+                function toggleTheme() {
+                    // Toggle dark class on html element
+                    const isDark = document.documentElement.classList.toggle('dark');
+                    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+                    updateThemeIcons();
 
-            // Function to update the visibility of the icons based on the current theme
-            function updateIcons() {
-                const darkIcon = document.getElementById('theme-toggle-dark-icon');
-                const lightIcon = document.getElementById('theme-toggle-light-icon');
-
-                if (document.documentElement.classList.contains('dark')) {
-                    darkIcon.classList.add('hidden');
-                    lightIcon.classList.remove('hidden');
-                } else {
-                    lightIcon.classList.add('hidden');
-                    darkIcon.classList.remove('hidden');
+                    // Dispatch custom event for Monaco editors
+                    document.dispatchEvent(new CustomEvent('themeChanged'));
                 }
-            }
 
-            // Add event listener to the theme toggle button
-            document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+                // Add event listener to the theme toggle button
+                document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
 
-            // Initialize the correct icon on page load
-            document.addEventListener('DOMContentLoaded', updateIcons);
-        </script>
+                // Initialize the correct icon on page load
+                document.addEventListener('DOMContentLoaded', updateThemeIcons);
+            </script>
+        {% endblock %}
     </body>
 </html>

--- a/app/templates/base.html.twig
+++ b/app/templates/base.html.twig
@@ -85,6 +85,9 @@
                     localStorage.theme = 'dark';
                 }
                 updateIcons();
+
+                // Dispatch custom event for Monaco editors
+                document.dispatchEvent(new CustomEvent('themeChanged'));
             }
 
             // Function to update the visibility of the icons based on the current theme

--- a/app/templates/playground/_form.html.twig
+++ b/app/templates/playground/_form.html.twig
@@ -6,29 +6,29 @@
 
 {{ form_start(form) }}
     <div class="flex">
-        <div class="flex-1 text-gray-700 bg-gray-200 px-1 py-1 my-2">
+        <div class="flex-1 text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 px-1 py-1 my-2 transition-colors duration-200">
             <div id="editor-code" style="height:400px;"></div>
             <div class="hidden">{{ form_widget(form.code) }}</div>
             {{ form_errors(form.code) }}
         </div>
-        <div class="flex-1 text-gray-700 bg-gray-200 px-1 py-1 m-2">
+        <div class="flex-1 text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 px-1 py-1 m-2 transition-colors duration-200">
             <div id="editor-test" style="height:400px;"></div>
             <div class="hidden">{{ form_widget(form.test) }}</div>
             {{ form_errors(form.test) }}
         </div>
-        <div class="flex-1 text-gray-700 bg-gray-200 px-1 py-1 m-2">
+        <div class="flex-1 text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 px-1 py-1 m-2 transition-colors duration-200">
             <div id="editor-config" style="height:400px;"></div>
             <div class="hidden">{{ form_widget(form.config) }}</div>
             {{ form_errors(form.config) }}
         </div>
     </div>
 
-    <button id="js-submit" class="bg-transparent hover:bg-green-500 text-green-700 font-semibold hover:text-white py-2 px-4 border border-green-500 hover:border-transparent rounded inline-flex items-center" type="button">
+    <button id="js-submit" class="bg-transparent dark:bg-gray-800 hover:bg-green-500 dark:hover:bg-green-600 text-green-700 dark:text-green-400 font-semibold hover:text-white dark:hover:text-white py-2 px-4 border border-green-500 dark:border-green-600 hover:border-transparent dark:hover:border-transparent rounded inline-flex items-center transition-colors duration-200" type="button">
         <svg class="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M4 4l12 6-12 6z"/></svg>
         <span>Run</span>
     </button>
     {% if resultOutput is defined %}
-        <button id="copy-url" type="button" class="bg-transparent hover:bg-green-500 text-green-700 font-semibold hover:text-white py-2 px-4 border border-green-500 hover:border-transparent rounded inline-flex items-center">
+        <button id="copy-url" type="button" class="bg-transparent dark:bg-gray-800 hover:bg-green-500 dark:hover:bg-green-600 text-green-700 dark:text-green-400 font-semibold hover:text-white dark:hover:text-white py-2 px-4 border border-green-500 dark:border-green-600 hover:border-transparent dark:hover:border-transparent rounded inline-flex items-center transition-colors duration-200">
             <svg class="fill-current w-4 h-4 mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M6 6V2c0-1.1.9-2 2-2h10a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-4v4a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V8c0-1.1.9-2 2-2h4zm2 0h4a2 2 0 0 1 2 2v4h4V2H8v4zM2 8v10h10V8H2z"/></svg>
             <span id="copy-btn-text">Copy URL</span>
         </button>
@@ -37,7 +37,7 @@
         {% endif %}
     {% endif %}
     {% if example is defined and example.infectionVersion and example.phpunitVersion %}
-        <span class="ml-5">Revision was created with Infection <span class="text-green-700">{{ example.infectionVersion }}</span>, PHPUnit <span class="text-green-700">{{ example.phpunitVersion }}</span> and PHP <span class="text-green-700">{{ example.phpVersion }}</span></span>
+        <span class="ml-5 dark:text-gray-300 transition-colors duration-200">Revision was created with Infection <span class="text-green-700 dark:text-green-400">{{ example.infectionVersion }}</span>, PHPUnit <span class="text-green-700 dark:text-green-400">{{ example.phpunitVersion }}</span> and PHP <span class="text-green-700 dark:text-green-400">{{ example.phpVersion }}</span></span>
     {% endif %}
     <div class="hidden">{{ form_rest(form) }}</div>
 {{ form_end(form) }}

--- a/app/templates/playground/create.html.twig
+++ b/app/templates/playground/create.html.twig
@@ -5,5 +5,6 @@
 {% endblock %}
 
 {% block javascripts %}
+    {{ parent() }}
     {{ encore_entry_script_tags('app') }}
 {% endblock %}

--- a/app/templates/playground/index.html.twig
+++ b/app/templates/playground/index.html.twig
@@ -8,13 +8,13 @@
     {% if resultOutput is defined %}
         <div class="mx-auto duration-500 ease-in-out transform max-w-screen-3xl py-4" data-class-toggler-target="toggleable">
             <div class="relative">
-                <div class="overflow-hidden shadow-md rounded-xl " style="transform-origin: right center;">
-                    <div class="flex items-center pl-3 space-x-1 bg-gray-200 rounded-t-xl h-7">
-                        <span class="w-2 h-2 bg-white rounded-full"></span>
-                        <span class="w-2 h-2 bg-white rounded-full"></span>
-                        <span class="w-2 h-2 bg-white rounded-full"></span>
+                <div class="overflow-hidden shadow-md rounded-xl dark:shadow-gray-700" style="transform-origin: right center;">
+                    <div class="flex items-center pl-3 space-x-1 bg-gray-200 dark:bg-gray-700 rounded-t-xl h-7">
+                        <span class="w-2 h-2 bg-white dark:bg-gray-400 rounded-full"></span>
+                        <span class="w-2 h-2 bg-white dark:bg-gray-400 rounded-full"></span>
+                        <span class="w-2 h-2 bg-white dark:bg-gray-400 rounded-full"></span>
                     </div>
-                    <pre style="overflow: auto; padding: 10px 15px; font-family: monospace;">{{ resultOutput|raw }}</pre>
+                    <pre class="bg-white dark:bg-gray-800 dark:text-gray-200 transition-colors duration-200" style="overflow: auto; padding: 10px 15px; font-family: monospace;">{{ resultOutput|raw }}</pre>
                 </div>
             </div>
         </div>
@@ -22,29 +22,29 @@
 
     {% if jsonLog is defined and jsonLog is not empty %}
         <div class="flex items-center py-4">
-            <div class="flex-1 border-t-2 border-gray-200"></div>
-            <span class="px-3 text-gray-500 bg-white">Generated Mutants</span>
-            <div class="flex-1 border-t-2 border-gray-200"></div>
+            <div class="flex-1 border-t-2 border-gray-200 dark:border-gray-700"></div>
+            <span class="px-3 text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-900 transition-colors duration-200">Generated Mutants</span>
+            <div class="flex-1 border-t-2 border-gray-200 dark:border-gray-700"></div>
         </div>
 
-        <div id="no-mutations-alert" class="hidden bg-yellow-100 border border-yellow-400 text-yellow-700 px-4 py-3 rounded relative" role="alert">
+        <div id="no-mutations-alert" class="hidden bg-yellow-100 dark:bg-yellow-800 border border-yellow-400 dark:border-yellow-600 text-yellow-700 dark:text-yellow-300 px-4 py-3 rounded relative" role="alert">
             <span class="block sm:inline">No mutants were generated for provided code and config file.</span>
         </div>
         <div id="mutants-log" class="px-2 pb-4">
             <div class="flex -mx-2">
                 <div class="w-1/3" style="height: 400px; overflow-y: scroll;">
-                    <div class="overflow-x-auto bg-white rounded overflow-y-auto relative">
-                        <table id="mutants-table" class="border-collapse table-auto w-full whitespace-no-wrap bg-white table-striped relative">
+                    <div class="overflow-x-auto bg-white dark:bg-gray-800 rounded overflow-y-auto relative transition-colors duration-200">
+                        <table id="mutants-table" class="border-collapse table-auto w-full whitespace-no-wrap bg-white dark:bg-gray-800 dark:text-gray-200 table-striped relative transition-colors duration-200">
                             <tbody>
                             </tbody>
                         </table>
                     </div>
                 </div>
                 <div class="w-1/3 px-2">
-                    <div id="editor-diff" style="height: 400px;"></div>
+                    <div id="editor-diff" class="dark:bg-gray-800 transition-colors duration-200" style="height: 400px;"></div>
                 </div>
                 <div class="w-1/3 px-2">
-                    <pre id="mutant-output" style="overflow: auto; padding: 10px 15px; font-family: monospace;"></pre>
+                    <pre id="mutant-output" class="bg-white dark:bg-gray-800 dark:text-gray-200 transition-colors duration-200" style="overflow: auto; padding: 10px 15px; font-family: monospace;"></pre>
                 </div>
             </div>
         </div>

--- a/app/templates/playground/index.html.twig
+++ b/app/templates/playground/index.html.twig
@@ -52,5 +52,6 @@
 {% endblock %}
 
 {% block javascripts %}
+    {{ parent() }}
     {{ encore_entry_script_tags('app') }}
 {% endblock %}

--- a/app/templates/playground/index.html.twig
+++ b/app/templates/playground/index.html.twig
@@ -14,7 +14,7 @@
                         <span class="w-2 h-2 bg-white dark:bg-gray-400 rounded-full"></span>
                         <span class="w-2 h-2 bg-white dark:bg-gray-400 rounded-full"></span>
                     </div>
-                    <pre class="bg-white dark:bg-gray-800 dark:text-gray-200 transition-colors duration-200" style="overflow: auto; padding: 10px 15px; font-family: monospace;">{{ resultOutput|raw }}</pre>
+                    <pre class="bg-white dark:bg-gray-800 dark:text-gray-200 transition-colors duration-200 ansi-theme-container" style="overflow: auto; padding: 10px 15px; font-family: monospace;">{{ resultOutput|raw }}</pre>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Add support for dark them by AI (JetBrains Junie)

This code is in 99% written by UI (JetBrainsJunie) which is a **nice experiment** when Junie is released.

While the code quality is not perfect, I'm ok here as I explicitly didn't want to use any JS frameworks here. As simple as that and it does the work!

Light theme:

<img width="1501" alt="image" src="https://github.com/user-attachments/assets/22282371-f1c1-42c9-a646-1a3dee34d55c" />

Dark theme:

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/a9fc0e00-302b-4de3-b966-ee04656c0db8" />

